### PR TITLE
Fix: Return wrong query syntax "SELECT FROM" when no tags and fields

### DIFF
--- a/influxalchemy/query.py
+++ b/influxalchemy/query.py
@@ -78,7 +78,9 @@ class InfluxDBQuery(object):
                         selects.append(field)
                 # pylint: disable=bare-except
                 except:
-                    selects = ["*"]
+                    pass
+        if not selects:
+            selects = ["*"]
         return selects
 
     @property

--- a/tests/query_test.py
+++ b/tests/query_test.py
@@ -115,3 +115,15 @@ def test_get_tags_fields(mock_fields, mock_tags):
     fizz = Measurement.new("fuzz")
     query = client.query(fizz)
     assert str(query) == "SELECT fizz, buzz, foo, goo FROM fuzz;"
+
+
+@mock.patch("influxalchemy.InfluxAlchemy.tags")
+@mock.patch("influxalchemy.InfluxAlchemy.fields")
+def test_get_empty_tags_fields(mock_fields, mock_tags):
+    mock_tags.return_value = []
+    mock_fields.return_value = []
+    db = influxdb.InfluxDBClient(database="example")
+    client = InfluxAlchemy(db)
+    fizz = Measurement.new("fuzz")
+    query = client.query(fizz)
+    assert str(query) == "SELECT * FROM fuzz;"


### PR DESCRIPTION
Sometimes, InfluxDB returns no result for both `SHOW tag keys` and `SHOW field keys`. This makes InfluxAlchemy compose wrong query syntax

```sql
SELECT FROM measurement_name`;
```

This PR is to fix that.